### PR TITLE
Update servers without requiring rebuild

### DIFF
--- a/src/controllers/docker.js
+++ b/src/controllers/docker.js
@@ -251,6 +251,36 @@ class Docker {
         });
     }
 
+    /**
+     * Updates usage liits without requiring a rebuild.
+     * @param  {Function} next
+     * @return {Callback}
+     */
+    update(next) {
+        // How Much Swap?
+        let swapSpace = 0;
+        if (this.server.json.build.swap < 0) {
+            swapSpace = -1;
+        } else if (this.server.json.build.swap > 0 && this.server.json.build.memory > 0) {
+            swapSpace = ((this.server.json.build.memory + this.server.json.build.swap) * 1000000);
+        }
+
+        this.container.update({
+            CpuQuota: (this.server.json.build.cpu > 0) ? (this.server.json.build.cpu * 1000) : -1,
+            CpuPeriod: (this.server.json.build.cpu > 0) ? 100000 : 0,
+            Memory: this.server.json.build.memory * 1000000,
+            MemorySwap: swapSpace,
+            BlkioWeight: this.server.json.build.io,
+        }, function (err) {
+            return next(err);
+        });
+    }
+
+    /**
+     * Rebuilds a given servers container.
+     * @param  {Function} next
+     * @return {Callback}
+     */
     rebuild(next) {
         const self = this;
         const config = this.server.json.build;

--- a/src/controllers/routes.js
+++ b/src/controllers/routes.js
@@ -170,7 +170,7 @@ class RouteController {
     // Sends command to server
     postServerCommand() {
         if (!Auth.allowed('s:command')) return;
-        if (!_.isUndefied(this.req.params.command)) {
+        if (!_.isUndefined(this.req.params.command)) {
             if (this.req.params.command.trim().replace(/^\/*/, '').startsWith(Auth.server().service.object.stop)) {
                 if (!Auth.allowed('s:power:stop')) return;
             }


### PR DESCRIPTION
You can now change server limits on the fly without having to rebuild the container each time. Makes use of the docker `update` command.

references #14 
