### PR TITLE
Add auto configuration script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "node src/index.js | node_modules/bunyan/bin/bunyan -o short",
-    "test": "./node_modules/eslint/bin/eslint.js --config .eslintrc src/*",
+    "test": "./node_modules/eslint/bin/eslint.js --config .eslintrc src/* scripts/*",
     "configure": "node scripts/configure.js"
   },
   "repository": {
@@ -53,7 +53,7 @@
     "fs-extra": "1.0.0",
     "gamedig": "0.2.25",
     "ini": "1.3.4",
-    "inquirer": "^2.0.0",
+    "inquirer": "2.0.0",
     "ip-cidr": "0.0.4",
     "is-json": "2.0.1",
     "isstream": "0.1.2",
@@ -70,7 +70,7 @@
     "rfr": "1.2.3",
     "socket.io": "1.5.0",
     "socketio-file-upload": "0.5.0",
-    "winston": "^2.3.0",
-    "yargs": "^6.6.0"
+    "winston": "2.3.0",
+    "yargs": "6.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "fs-extra": "1.0.0",
     "gamedig": "0.2.25",
     "ini": "1.3.4",
-    "ip-cidr": "0.0.4",
     "inquirer": "^2.0.0",
+    "ip-cidr": "0.0.4",
     "is-json": "2.0.1",
     "isstream": "0.1.2",
     "lodash": "4.17.2",
@@ -70,6 +70,7 @@
     "rfr": "1.2.3",
     "socket.io": "1.5.0",
     "socketio-file-upload": "0.5.0",
+    "winston": "^2.3.0",
     "yargs": "^6.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "start": "node src/index.js | node_modules/bunyan/bin/bunyan -o short",
-    "test": "./node_modules/eslint/bin/eslint.js --config .eslintrc src/*"
+    "test": "./node_modules/eslint/bin/eslint.js --config .eslintrc src/*",
+    "configure": "node scripts/configure.js"
   },
   "repository": {
     "type": "git",
@@ -53,6 +54,7 @@
     "gamedig": "0.2.25",
     "ini": "1.3.4",
     "ip-cidr": "0.0.4",
+    "inquirer": "^2.0.0",
     "is-json": "2.0.1",
     "isstream": "0.1.2",
     "lodash": "4.17.2",
@@ -67,6 +69,7 @@
     "restify": "4.3.0",
     "rfr": "1.2.3",
     "socket.io": "1.5.0",
-    "socketio-file-upload": "0.5.0"
+    "socketio-file-upload": "0.5.0",
+    "yargs": "^6.6.0"
   }
 }

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -1,0 +1,63 @@
+const _ = require('lodash');
+const inquirer = require('inquirer');
+
+const argv = require('yargs')
+  .usage('npm run configure -- <arguments>')
+  .describe('n', 'The name of the node to configure')
+  .alias('n', 'node-name')
+  .describe('t', 'An API token to use. Allows to skip login')
+  .alias('t', 'api-token')
+  .describe('u', 'An admin username to login with. Avoids API token use')
+  .alias('u', 'username')
+  .describe('p', 'An admin password to login with. Not recommended, use a token or interactive login')
+  .alias('p', 'password')
+  .describe('h', 'Show this help')
+  .alias('h', 'help')
+  .help('h')
+  .argv;
+
+const options = {
+    nodename: argv.n,
+    token: argv.t,
+    username: argv.u,
+    password: argv.p,
+};
+
+inquirer.prompt([
+    {
+        name: 'nodename',
+        type: 'string',
+        message: 'The name of the node to configure:',
+        when: () => _.isUndefined(options.nodename),
+        validate: input => (input === '' ? 'The node name is required' : true),
+    },
+    {
+        name: 'token',
+        type: 'string',
+        message: 'An API Token to use (Enter nothing to use login with username and password instead):',
+        default: '',
+        when: () => _.isUndefined(options.token) && _.isUndefined(options.username),
+    },
+    {
+        name: 'username',
+        type: 'string',
+        message: 'An admin username:',
+        when: answers => _.isUndefined(options.token) && answers.token === '' && _.isUndefined(options.username),
+        validate: input => (input === '' ? 'Either a token or a user is required!' : true),
+    },
+    {
+        name: 'password',
+        type: 'password',
+        message: 'Password:',
+        when: answers => _.isString(options.username) || _.isString(answers.username),
+        validate: input => (input === '' ? 'A password is required' : true),
+    },
+]).then(answers => {
+    _.forEach(answers, (answer, key) => {
+        options[key] = answer;
+    });
+
+    console.log(options);
+
+    // TODO actualy configure stuff.
+});

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -1,33 +1,45 @@
 const _ = require('lodash');
 const inquirer = require('inquirer');
+//const request = require('request');
+const url = require('url');
 
 const argv = require('yargs')
-  .usage('npm run configure -- <arguments>')
-  .describe('n', 'The name of the node to configure')
-  .alias('n', 'node-name')
-  .describe('t', 'An API token to use. Allows to skip login')
-  .alias('t', 'api-token')
-  .describe('u', 'An admin username to login with. Avoids API token use')
-  .alias('u', 'username')
-  .describe('p', 'An admin password to login with. Not recommended, use a token or interactive login')
-  .alias('p', 'password')
-  .describe('h', 'Show this help')
-  .alias('h', 'help')
-  .help('h')
-  .argv;
+    .usage('npm run configure -- <arguments>')
+    .describe('p', 'The url to the panel the node should be added to')
+    .alias('p', 'panel-url')
+    .describe('n', 'The name of the node to configure')
+    .alias('n', 'node-name')
+    .describe('t', 'An API token to use. Allows to skip login')
+    .alias('t', 'api-token')
+    .describe('u', 'An admin username to login with. Avoids API token use')
+    .alias('u', 'username')
+    .describe('password', 'An admin password to login with. Not recommended, use a token or interactive login')
+    .describe('h', 'Show this help')
+    .alias('h', 'help')
+    .help('h')
+    .argv;
 
 const options = {
+    panelurl: argv.p,
     nodename: argv.n,
     token: argv.t,
     username: argv.u,
-    password: argv.p,
+    password: argv.password,
 };
 
 inquirer.prompt([
     {
+        name: 'panelurl',
+        type: 'string',
+        message: 'Url of the panel to add the node to:',
+        when: () => _.isUndefined(options.panelurl),
+        validate: input => (input === '' ? 'The panel url is required' : true),
+        format: input => url.format(url.parse(input)),
+    },
+    {
         name: 'nodename',
         type: 'string',
-        message: 'The name of the node to configure:',
+        message: 'Name of the node to configure:',
         when: () => _.isUndefined(options.nodename),
         validate: input => (input === '' ? 'The node name is required' : true),
     },
@@ -43,13 +55,13 @@ inquirer.prompt([
         type: 'string',
         message: 'An admin username:',
         when: answers => _.isUndefined(options.token) && answers.token === '' && _.isUndefined(options.username),
-        validate: input => (input === '' ? 'Either a token or a user is required!' : true),
+        validate: input => (input === '' ? 'Either a token or a user is required' : true),
     },
     {
         name: 'password',
         type: 'password',
         message: 'Password:',
-        when: answers => _.isString(options.username) || _.isString(answers.username),
+        when: answers => _.isUndefined(options.password) && (_.isString(options.username) || _.isString(answers.username)),
         validate: input => (input === '' ? 'A password is required' : true),
     },
 ]).then(answers => {

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -1,75 +1,151 @@
 const _ = require('lodash');
 const inquirer = require('inquirer');
-//const request = require('request');
-const url = require('url');
+const winston = require('winston');
+const request = require('request');
+const fs = require('fs');
+const path = require('path');
 
-const argv = require('yargs')
-    .usage('npm run configure -- <arguments>')
-    .describe('p', 'The url to the panel the node should be added to')
-    .alias('p', 'panel-url')
-    .describe('n', 'The name of the node to configure')
-    .alias('n', 'node-name')
-    .describe('t', 'An API token to use. Allows to skip login')
-    .alias('t', 'api-token')
-    .describe('u', 'An admin username to login with. Avoids API token use')
-    .alias('u', 'username')
-    .describe('password', 'An admin password to login with. Not recommended, use a token or interactive login')
-    .describe('h', 'Show this help')
-    .alias('h', 'help')
-    .help('h')
-    .argv;
+const configFilePath = path.resolve(__dirname, '../config/core.json');
 
-const options = {
-    panelurl: argv.p,
-    nodename: argv.n,
-    token: argv.t,
-    username: argv.u,
-    password: argv.password,
+const log = new winston.Logger({
+    transports: [new winston.transports.Console({
+        level: 'info',
+        handleExceptions: true,
+        colorize: true,
+    })],
+});
+
+const regex = {
+    fqdn: new RegExp(/^https?:\/\/(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,64}\/?$/),
+    ipv4: new RegExp(/((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4}/),
 };
 
-inquirer.prompt([
-    {
-        name: 'panelurl',
-        type: 'string',
-        message: 'Url of the panel to add the node to:',
-        when: () => _.isUndefined(options.panelurl),
-        validate: input => (input === '' ? 'The panel url is required' : true),
-        format: input => url.format(url.parse(input)),
+const argv = require('yargs')
+.usage('npm run configure -- <arguments>')
+    .describe('p', 'The panel url to pull the configuration from')
+    .alias('p', 'panel-url')
+    .describe('t', 'The configuration token')
+    .alias('t', 'token')
+    .boolean('o')
+    .describe('o', 'Overwrite existing configuration file')
+    .alias('o', 'overwrite')
+    .alias('h', 'help')
+    .help('h').argv;
+
+const params = {
+    panelurl: {
+        name: 'Panel url',
+        value: argv.p,
+        validate: value => {
+            if (value === '') {
+                return 'The panel url is required';
+            }
+            if (!value.match(regex.fqdn) && !value.match(regex.ipv4)) {
+                return 'Please provide either a URL (with protocol) or an IPv4 address.';
+            }
+            return true;
+        },
     },
-    {
-        name: 'nodename',
-        type: 'string',
-        message: 'Name of the node to configure:',
-        when: () => _.isUndefined(options.nodename),
-        validate: input => (input === '' ? 'The node name is required' : true),
+    token: {
+        name: 'Configuration token',
+        value: argv.t,
+        validate: value => {
+            if (value === '') {
+                return 'A configuration token is required.';
+            }
+            if (value.length !== 32) {
+                return 'The token provided is invalid. It must be 32 characters long.';
+            }
+            return true;
+        },
     },
-    {
-        name: 'token',
-        type: 'string',
-        message: 'An API Token to use (Enter nothing to use login with username and password instead):',
-        default: '',
-        when: () => _.isUndefined(options.token) && _.isUndefined(options.username),
+    overwrite: {
+        name: 'Overwrite',
+        value: argv.o,
     },
-    {
-        name: 'username',
-        type: 'string',
-        message: 'An admin username:',
-        when: answers => _.isUndefined(options.token) && answers.token === '' && _.isUndefined(options.username),
-        validate: input => (input === '' ? 'Either a token or a user is required' : true),
-    },
-    {
-        name: 'password',
-        type: 'password',
-        message: 'Password:',
-        when: answers => _.isUndefined(options.password) && (_.isString(options.username) || _.isString(answers.username)),
-        validate: input => (input === '' ? 'A password is required' : true),
-    },
-]).then(answers => {
-    _.forEach(answers, (answer, key) => {
-        options[key] = answer;
+};
+
+// Validate and filter the provided command line params
+function validateParams() {
+    _.forEach(params, (option, key) => {
+        if (!_.isUndefined(option.value)) {
+            if (_.isFunction(option.validate)) {
+                const valResult = option.validate(option.value);
+                if (valResult !== true) {
+                    log.error(`${option.name}: ${valResult}`);
+                    params[key].value = undefined;
+                    return;
+                }
+            }
+        }
     });
+}
 
-    console.log(options);
+function main() {
+    const configExists = fs.existsSync(configFilePath);
 
-    // TODO actualy configure stuff.
-});
+    if (configExists) log.debug('Config already exists.');
+
+    inquirer.prompt([
+        {
+            name: 'panelurl',
+            type: 'string',
+            message: 'Url of the panel to add the node to:',
+            when: () => _.isUndefined(params.panelurl.value),
+            validate: params.panelurl.validate,
+        }, {
+            name: 'token',
+            type: 'string',
+            message: 'A configuration token to use:',
+            when: () => _.isUndefined(params.token.value),
+            validate: params.token.validate,
+        }, {
+            name: 'overwrite',
+            type: 'confirm',
+            default: false,
+            message: 'Overwrite existing configuration?',
+            when: () => !params.overwrite.value && configExists,
+        },
+    ]).then(answers => {
+        _.forEach(answers, (answer, key) => {
+            params[key].value = answer;
+        });
+
+        if (!params.overwrite.value && configExists) {
+            log.error('Configuration already exists. Aborting.');
+            return;
+        }
+
+        log.info('Trying to fetch configuration from the panel...');
+
+        request(`${params.panelurl.value}/remote/configuration/${params.token.value}`, (error, response, body) => {
+            if (!error) {
+                const jsonBody = JSON.parse(body);
+                if (response.statusCode === 200) {
+                    log.info('Writing configuration file...');
+
+                    fs.writeFile(configFilePath, JSON.stringify(jsonBody, null, 4), err => {
+                        if (err) {
+                            log.error('Failed to write configuration file.');
+                        } else {
+                            log.info('Configuration written successfully.');
+                        }
+                    });
+                } else if (response.statusCode === 403) {
+                    if (jsonBody.error === 'token_invalid') {
+                        log.error('The token you used is invalid.');
+                    } else if (jsonBody.error === 'token_expired') {
+                        log.error('The token you used is expired.');
+                    } else {
+                        log.error('An unknown error occured!', body);
+                    }
+                }
+            } else {
+                log.error('Sorry. Something went wrong fetching the configuration.');
+            }
+        });
+    });
+}
+
+validateParams();
+main();

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -20,22 +20,10 @@ const regex = {
     ipv4: new RegExp(/((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4}/),
 };
 
-const argv = require('yargs')
-.usage('npm run configure -- <arguments>')
-    .describe('p', 'The panel url to pull the configuration from')
-    .alias('p', 'panel-url')
-    .describe('t', 'The configuration token')
-    .alias('t', 'token')
-    .boolean('o')
-    .describe('o', 'Overwrite existing configuration file')
-    .alias('o', 'overwrite')
-    .alias('h', 'help')
-    .help('h').argv;
-
 const params = {
     panelurl: {
         name: 'Panel url',
-        value: argv.p,
+        cmdoption: 'p',
         validate: value => {
             if (value === '') {
                 return 'The panel url is required';
@@ -48,7 +36,7 @@ const params = {
     },
     token: {
         name: 'Configuration token',
-        value: argv.t,
+        cmdoption: 't',
         validate: value => {
             if (value === '') {
                 return 'A configuration token is required.';
@@ -61,91 +49,118 @@ const params = {
     },
     overwrite: {
         name: 'Overwrite',
-        value: argv.o,
+        cmdoption: 'c',
     },
 };
 
-// Validate and filter the provided command line params
-function validateParams() {
-    _.forEach(params, (option, key) => {
-        if (!_.isUndefined(option.value)) {
-            if (_.isFunction(option.validate)) {
-                const valResult = option.validate(option.value);
-                if (valResult !== true) {
-                    log.error(`${option.name}: ${valResult}`);
-                    params[key].value = undefined;
-                    return;
-                }
+/**
+ * yargs compatible method for validating the arguments
+ */
+function checkParams(arg) {
+    _.forEach(params, param => {
+        if (_.has(arg, param.cmdoption)) {
+            const valResult = param.validate(arg[param.cmdoption]);
+            if (valResult !== true) {
+                throw new Error(`${param.name}: ${valResult}`);
             }
         }
     });
+    return true;
 }
 
-function main() {
-    const configExists = fs.existsSync(configFilePath);
+// Parse provided arguments with yargs for insanly easier usage
+const argv = require('yargs')
+    .usage('npm run configure -- <arguments>')
+    .describe('p', 'The panel url to pull the configuration from')
+    .alias('p', 'panel-url')
+    .describe('t', 'The configuration token')
+    .alias('t', 'token')
+    .boolean('o')
+    .describe('o', 'Overwrite existing configuration file')
+    .alias('o', 'overwrite')
+    .alias('h', 'help')
+    .check(checkParams)
+    .help('h')
+    .fail((msg, err, yargs) => {
+        log.error(err.message);
+        log.info(yargs.help());
+        process.exit();
+    })
+    .argv;
 
-    if (configExists) log.debug('Config already exists.');
+// Put the provided values into the overly complicated params object
+_.forEach(params, (param, key) => {
+    if (_.has(argv, param.cmdoption)) {
+        params[key].value = argv[param.cmdoption];
+    }
+});
 
-    inquirer.prompt([
-        {
-            name: 'panelurl',
-            type: 'string',
-            message: 'Url of the panel to add the node to:',
-            when: () => _.isUndefined(params.panelurl.value),
-            validate: params.panelurl.validate,
-        }, {
-            name: 'token',
-            type: 'string',
-            message: 'A configuration token to use:',
-            when: () => _.isUndefined(params.token.value),
-            validate: params.token.validate,
-        }, {
-            name: 'overwrite',
-            type: 'confirm',
-            default: false,
-            message: 'Overwrite existing configuration?',
-            when: () => !params.overwrite.value && configExists,
-        },
-    ]).then(answers => {
-        _.forEach(answers, (answer, key) => {
-            params[key].value = answer;
-        });
+// Check if the configuration file exists already
+const configExists = fs.existsSync(configFilePath);
+if (configExists) log.debug('Config already exists.');
 
-        if (!params.overwrite.value && configExists) {
-            log.error('Configuration already exists. Aborting.');
-            return;
-        }
+// Interactive questioning of missing parameters
+inquirer.prompt([
+    {
+        name: 'panelurl',
+        type: 'string',
+        message: 'Url of the panel to add the node to:',
+        when: () => _.isUndefined(params.panelurl.value),
+        validate: params.panelurl.validate,
+    }, {
+        name: 'token',
+        type: 'string',
+        message: 'A configuration token to use:',
+        when: () => _.isUndefined(params.token.value),
+        validate: params.token.validate,
+    }, {
+        // Will only be asked if file exists and no overwrite flag is set
+        name: 'overwrite',
+        type: 'confirm',
+        default: false,
+        message: 'Overwrite existing configuration?',
+        when: () => !params.overwrite.value && configExists,
+    },
+]).then(answers => {
+    // Overwrite the values in the overly complicated params object
+    _.forEach(answers, (answer, key) => {
+        params[key].value = answer;
+    });
 
-        log.info('Trying to fetch configuration from the panel...');
+    // If file exists and no overwrite wanted error and exit.
+    if (!params.overwrite.value && configExists) {
+        log.error('Configuration already exists. Aborting.');
+        process.exit();
+    }
 
-        request(`${params.panelurl.value}/remote/configuration/${params.token.value}`, (error, response, body) => {
-            if (!error) {
-                const jsonBody = JSON.parse(body);
-                if (response.statusCode === 200) {
-                    log.info('Writing configuration file...');
+    // Fetch configuration from the panel
+    log.info('Trying to fetch configuration from the panel...');
+    request(`${params.panelurl.value}/remote/configuration/${params.token.value}`, (error, response, body) => {
+        if (!error) {
+            // response should always be JSON
+            const jsonBody = JSON.parse(body);
 
-                    fs.writeFile(configFilePath, JSON.stringify(jsonBody, null, 4), err => {
-                        if (err) {
-                            log.error('Failed to write configuration file.');
-                        } else {
-                            log.info('Configuration written successfully.');
-                        }
-                    });
-                } else if (response.statusCode === 403) {
-                    if (jsonBody.error === 'token_invalid') {
-                        log.error('The token you used is invalid.');
-                    } else if (jsonBody.error === 'token_expired') {
-                        log.error('The token you used is expired.');
+            if (response.statusCode === 200) {
+                log.info('Writing configuration file...');
+
+                fs.writeFile(configFilePath, JSON.stringify(jsonBody, null, 4), err => {
+                    if (err) {
+                        log.error('Failed to write configuration file.');
                     } else {
-                        log.error('An unknown error occured!', body);
+                        log.info('Configuration written successfully.');
                     }
+                });
+            } else if (response.statusCode === 403) {
+                if (jsonBody.error === 'token_invalid') {
+                    log.error('The token you used is invalid.');
+                } else if (jsonBody.error === 'token_expired') {
+                    log.error('The token you used is expired.');
+                } else {
+                    log.error('An unknown error occured!', body);
                 }
-            } else {
-                log.error('Sorry. Something went wrong fetching the configuration.');
             }
-        });
+        } else {
+            log.error('Sorry. Something went wrong fetching the configuration.');
+        }
     });
-}
-
-validateParams();
-main();
+});


### PR DESCRIPTION
A script that allows to fetch the configuration from the panel.

Usage: `npm run configure -- -h`, the double `--` is required between arguments.
If required parameters are not provided via command line the script is interactive and asks for them.

the `-o` flag will force overwrite, without it the script will ask if it should overwrite.

There is some room for code improvements. Some stuff can be simplified probably, just created this for first looks at it.

Pterodactyl/Panel#242 & Pterodactyl/Panel#218