### PR TITLE
Fix for #593

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,11 +113,11 @@ Async.auto({
         Log.info('Configuring timezone file location...');
         Timezone.configure(callback);
     }],
-    setup_network: ['check_network', (r, callback) => {
+    setup_network: ['check_network', 'setup_timezone', (r, callback) => {
         Log.info('Checking pterodactyl0 interface and setting configuration values.');
         Network.interface(callback);
     }],
-    start_sftp: ['setup_network', 'setup_timezone', (r, callback) => {
+    start_sftp: ['setup_network', (r, callback) => {
         Log.info('Attempting to start SFTP service container...');
         SFTP.startService(err => {
             if (err) return callback(err);


### PR DESCRIPTION
Fixes [#593](https://github.com/Pterodactyl/Panel/issues/593). Thanks to JGSgamer for helping me to debug this.
Basically both, setup_network and setup_timezone try to use Config.modify and update values. The problem is its done at the same time and setup_network ends up overwriting setup_timezone's changes due to being called last, and pulling old config from cache, before setup_timezone updates cache.