### PR TITLE
Finish overlay and add weave networking support.

### DIFF
--- a/src/controllers/docker.js
+++ b/src/controllers/docker.js
@@ -362,7 +362,7 @@ class Docker {
                 const Container = {
                     Image: _.trimStart(config.image, '~'),
                     name: this.server.json.uuid,
-                    Hostname: this.server.json.uuid,
+                    Hostname: Config.get('docker.network.hostname', this.server.json.uuid).toString(),
                     User: Config.get('docker.container.user', 1000).toString(),
                     AttachStdin: true,
                     AttachStdout: true,

--- a/src/controllers/network.js
+++ b/src/controllers/network.js
@@ -109,8 +109,8 @@ class Network {
             }
 
             if (_.get(data, 'Driver') === 'overlay') {
-                Log.warn('Detected daemon configuation using OVERLAY NETWORK for server containers.');
-                Log.info('Removing interface address and enabling ispn.');
+                Log.info('Detected daemon configuation using OVERLAY NETWORK for server containers.');
+                Log.warn('Removing interface address and enabling ispn.');
                 Config.modify({
                     docker: {
                         interface: '',
@@ -123,8 +123,8 @@ class Network {
             }
 
             if (_.get(data, 'Driver') === 'weavemesh') {
-                Log.warn('Detected daemon configuation using WEAVEMESH NETWORK for server containers.');
-                Log.info('Removing interface address and enabling ispn.');
+                Log.info('Detected daemon configuation using WEAVEMESH NETWORK for server containers.');
+                Log.warn('Removing interface address and enabling ispn.');
                 Config.modify({
                     docker: {
                         interface: '',

--- a/src/controllers/network.js
+++ b/src/controllers/network.js
@@ -108,6 +108,34 @@ class Network {
                 return;
             }
 
+            if (_.get(data, 'Driver') === 'overlay') {
+                Log.warn('Detected daemon configuation using OVERLAY NETWORK for server containers.');
+                Log.info('Removing interface address and enabling ispn.');
+                Config.modify({
+                    docker: {
+                        interface: '',
+                        network: {
+                            ispn: true,
+                        },
+                    },
+                }, next);
+                return;
+            }
+
+            if (_.get(data, 'Driver') === 'weavemesh') {
+                Log.warn('Detected daemon configuation using WEAVEMESH NETWORK for server containers.');
+                Log.info('Removing interface address and enabling ispn.');
+                Config.modify({
+                    docker: {
+                        interface: '',
+                        network: {
+                            ispn: true,
+                        },
+                    },
+                }, next);
+                return;
+            }
+
             if (!_.get(data, 'IPAM.Config[0].Gateway', false)) {
                 return next(new Error('No gateway could be found for pterodactyl0.'));
             }


### PR DESCRIPTION
[Weave](https://www.weave.works/oss/net/) networking is a much simpler alternative to overlay networking which currently requires a key-value store or docker swarm which neither the current Daemon nor wings supports.

Very little is required to make it work with the current daemon and the changes already made to support overlay networking. For weave to add a container to it's internal DNS server the hostname of the container must be configured as `weave.local`. Please keep in mind this does not effect the overall container name the container is still accessible via the hostname `container-uuid` or `container-uuid.weave.local`

To configure the daemon to use weave the following options much be changed in the core daemon configuration:

*Please note the weave docker network is already created by weave on startup the daemon does not build the network.*

docker.socket: `/var/run/weave/weave.sock` - **Weave proxy of docker socket.**
docker.network.name: `weave` - **Name of already created weave network.**
docker.network.driver: `weavemesh` - **Driver of already created weave network.**
docker.network.hostname: `weave.local` - **Required for container to be added to weave-dns.**
docker.network.interfaces.v4.subnet:  `10.32.0.0/12` - **Default weave network subnet.**
docker.network.interfaces.v4.gateway: `""` - **Weave networks have no gateway**
docker.dns: `["172.17.0.1"]` - **Weave DNS address required for container address resolving.**
docker.interface: `""` - **Weave networks have no gateway**

With both overlay and weave networks the network interface has no gateway address which without ispn on Pterodactyl remapped `127.0.0.1` port allocations to. This practice is really not recommended and causes a number of compatibility issues. Containers can already access one another if they are on the same network via their hostnames which is explained above.