### PR TITLE
Add pump to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "moment": "2.20.1",
     "node-yaml": "^3.1.1",
     "properties-parser": "0.3.1",
+    "pump": "3.0.0",
     "randomstring": "1.1.5",
     "request": "2.83.0",
     "restify": "4.3.1",


### PR DESCRIPTION
This PR fixes error `Cannot find module 'pump'` after fresh install.

Full error message:
```
Error: Cannot find module 'pump'
    at Function.Module._resolveFilename (module.js:538:15)
    at Function.Module._load (module.js:468:25)
    at Module.require (module.js:587:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/srv/daemon/node_modules/tar-fs/index.js:2:12)
    at Module._compile (module.js:643:30)
    at Object.Module._extensions..js (module.js:654:10)
    at Module.load (module.js:556:32)
    at tryModuleLoad (module.js:499:12)
    at Function.Module._load (module.js:491:3)
```
