### PR TITLE
Queue sftp calls per directory

### DIFF
--- a/.dev/vagrant/provision.sh
+++ b/.dev/vagrant/provision.sh
@@ -4,11 +4,11 @@ echo "Provisioning development environment for Pterodactyl Panel."
 cp /srv/daemon/.dev/vagrant/motd.txt /etc/motd
 
 echo "Install docker"
-curl -sSL https://get.docker.com/ | sh
+curl -sSL https://get.docker.com/ | sh > /dev/null
 systemctl enable docker
 
 echo "Install nodejs"
-curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - > /dev/null
 apt-get -y install nodejs > /dev/null
 
 echo "Install additional dependencies"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-    config.vm.box = "ubuntu/xenial64"
+    config.vm.box = "bento/ubuntu-16.04"
 
     config.vm.synced_folder "./", "/srv/daemon",
         owner: "root", group: "root"

--- a/src/controllers/docker.js
+++ b/src/controllers/docker.js
@@ -445,7 +445,7 @@ class Docker {
                     callback(err, container);
                 });
             }],
-        }, (err, data) => {
+        }, err => {
             if (err) return next(err);
             return next(null, {
                 image: _.trimStart(config.image, '~'),

--- a/src/controllers/routes.js
+++ b/src/controllers/routes.js
@@ -587,9 +587,7 @@ class RouteController {
                     Log.warn({ res_code: response.statusCode, res_body: body }, 'An error occured while attempting to retrieve file download information for an upstream provider.');
                 }
 
-                this.res.redirect(this.req.header('Referer') || Config.get('remote.base'), () => {
-                    return '';
-                });
+                this.res.redirect(this.req.header('Referer') || Config.get('remote.base'), _.constant(''));
             }
         });
     }

--- a/src/helpers/sftpqueue.js
+++ b/src/helpers/sftpqueue.js
@@ -1,0 +1,65 @@
+'use strict';
+
+/**
+ * Pterodactyl - Daemon
+ * Copyright (c) 2015 - 2018 Dane Everitt <dane@daneeveritt.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const _ = require('lodash');
+
+class SFTPQueue {
+    constructor() {
+        this.tasks = {};
+        this.handlers = {};
+    }
+
+    push(location, task) {
+        console.log(this.handlers)
+        if (this.handlers[location]) {
+            console.log('queueing');
+            if (this.tasks[location] == null) this.tasks[location] = [];
+            this.tasks[location].push(task);
+        } else {
+            this.handleTask(location, task);
+        }
+    }
+
+    handleTask(location, task) {
+        this.handlers[location] = true;
+
+        const done = () => {
+            if (_.isArray(this.tasks[location]) && this.tasks[location].length > 0) {
+                this.handleTask(location, this.tasks[location].shift());
+            } else {
+                this.handlers[location] = false;
+            }
+        };
+
+        task(done);
+    }
+
+    clean() {
+        this.tasks = {};
+        this.handlers = {};
+    }
+}
+
+module.exports = SFTPQueue;

--- a/src/helpers/sftpqueue.js
+++ b/src/helpers/sftpqueue.js
@@ -33,7 +33,10 @@ class SFTPQueue {
 
     push(location, task) {
         if (this.handlers[location]) {
-            if (this.tasks[location] == null) this.tasks[location] = [];
+            if (!_.isArray(this.tasks[location])) {
+                this.tasks[location] = [];
+            }
+
             this.tasks[location].push(task);
         } else {
             this.handleTask(location, task);
@@ -43,15 +46,13 @@ class SFTPQueue {
     handleTask(location, task) {
         this.handlers[location] = true;
 
-        const done = () => {
+        task(() => {
             if (_.isArray(this.tasks[location]) && this.tasks[location].length > 0) {
                 this.handleTask(location, this.tasks[location].shift());
             } else {
                 this.handlers[location] = false;
             }
-        };
-
-        task(done);
+        });
     }
 
     clean() {

--- a/src/http/sftp.js
+++ b/src/http/sftp.js
@@ -210,6 +210,7 @@ class InternalSftpServer {
                                 });
                             });
                         };
+
                         sftp.on('READDIR', (reqId, handle) => {
                             const requestData = _.get(clientContext.handles, handle, null);
                             queue.push(requestData.path, done => {
@@ -328,6 +329,7 @@ class InternalSftpServer {
                                 });
                             });
                         };
+
                         sftp.on('OPEN', (reqId, location, flags) => {
                             queue.push(location, done => {
                                 open(reqId, location, flags, done);
@@ -364,6 +366,7 @@ class InternalSftpServer {
                                 });
                             });
                         };
+
                         sftp.on('READ', (reqId, handle, offset, length) => {
                             const requestData = _.get(clientContext.handles, handle, null);
                             queue.push(requestData.location, done => {
@@ -393,6 +396,7 @@ class InternalSftpServer {
                                 return sftp.status(reqId, err ? STATUS_CODE.FAILURE : STATUS_CODE.OK);
                             });
                         };
+
                         sftp.on('SETSTAT', (reqId, location, attrs) => {
                             queue.push(location, done => {
                                 setStat(reqId, location, attrs);
@@ -434,6 +438,7 @@ class InternalSftpServer {
                                 });
                             });
                         };
+
                         sftp.on('WRITE', (reqId, handle, offset, data) => {
                             const requestData = _.get(clientContext.handles, handle, null);
                             queue.push(requestData.path, done => {
@@ -461,6 +466,7 @@ class InternalSftpServer {
                                 });
                             });
                         };
+
                         sftp.on('MKDIR', (reqId, location) => {
                             queue.push(location, done => {
                                 mkdir(reqId, location);
@@ -494,6 +500,7 @@ class InternalSftpServer {
                                 });
                             });
                         };
+
                         sftp.on('RENAME', (reqId, oldPath, newPath) => {
                             queue.push(oldPath, done => {
                                 rename(reqId, oldPath, newPath);
@@ -530,6 +537,7 @@ class InternalSftpServer {
                                 });
                             });
                         };
+
                         sftp.on('RMDIR', (reqId, path) => {
                             queue.push(path, done => {
                                 rmdir(reqId, path);


### PR DESCRIPTION
This is a better fix for the sftp issues described in pterodactyl/panel#1099.

SFTP requests get queued per directory (using the SFTPQueue helper class, this is basically a queue with namespaces or something) and therefore requests regarding the same file/folder are handled one after another as required by the sftp specification.

This makes 98d4892a295c5b40ec24c9706179c366350b3f7d unnecessary and reverts it.