### PR TITLE
don't clean sftp queue on clean event

### DIFF
--- a/src/http/sftp.js
+++ b/src/http/sftp.js
@@ -556,8 +556,6 @@ class InternalSftpServer {
 
                         // Cleanup things.
                         sftp.on('CLOSE', (reqId, handle) => {
-                            queue.clean();
-
                             const requestData = _.get(clientContext.handles, handle, null);
                             if (!_.isNull(requestData)) {
                                 // If the writer is still active, close it and chown the item


### PR DESCRIPTION
it will get garbage collected when the connection is closed anyways and could lead to errors