### PR TITLE
Treat a non-zero status result from the install script as an error

### DIFF
--- a/src/controllers/option.js
+++ b/src/controllers/option.js
@@ -165,6 +165,10 @@ class Option {
                         container.remove();
                     }
 
+                    if (data.StatusCode !== 0) {
+                        return callback(new Error(`Install script failed with code ${data.StatusCode}`));
+                    }
+
                     if (err) {
                         return callback(err);
                     }


### PR DESCRIPTION
If the install script exits with a non-zero status code, the daemon will now return the value `installed: 'error'` to the panel, which will then mark the server as failed in the database.