### PR TITLE
Add 1:1 NAT feature

### DIFF
--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -371,7 +371,7 @@ class Server extends EventEmitter {
                 this.docker.start(callback);
             },
             callback => {
-                if (Config.get('docker.network.name') !== 'host' && (Config.get('docker.policy.network.enable_ip_masquerade') === 'false' || Config.get('docker.policy.network.enable_ip_masquerade') ==$
+                if (Config.get('docker.network.name') !== 'host' && (Config.get('docker.policy.network.enable_ip_masquerade') === 'false' || Config.get('docker.policy.network.enable_ip_masquerade') === false)) {
                     const NETWORK_NAME = Config.get('docker.network.name');
                     this.docker.container.inspect().then(results => {
                         const props = {


### PR DESCRIPTION
Just a quick and dirty 1:1 NAT implementation on docker containers.
I'm sure someone with better skills can write/correct what I tried to implement, unfortunately I'm not a software developer.

NAT 1:1 permits to run every kind of gameserver behind a NAT interface, without the need to use a "host" network interface. The "host" network interface unfortunately can not run games that do not support multihome IP. NAT 1:1 can do that and the security between containers is mantained.
There's no need to manage iptables rules, these rules can just be corrected on server start, no need to remove them on server stop/kill.

Thx for considering my 2 cents.