### PR TITLE
Add NAT 1:1 feature

### DIFF
--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -384,7 +384,8 @@ class Server extends EventEmitter {
 
                         // Removes all container related NAT rules
                         // TODO : Check result code and report log/console
-                        this.emit('console', `${Ansi.style.green}[Pterodactyl Daemon] Removing 1:1 NAT iptables rule: Internal=${IntIPAddress} / External=${ExtIPAddress} on Interface ${NETWORK_NAME}`);
+                        this.emit('console', `${Ansi.style.green}[Pterodactyl Daemon] Configuring 1:1 1:1 Network.`);
+                        this.log.info(`Removing all 1:1 NAT iptables rules: Internal=${IntIPAddress} / External=${ExtIPAddress} on Interface ${NETWORK_NAME}`);
                         const iptList = Process.spawn('iptables', ['-t', 'nat', '-L', 'POSTROUTING', '--line-numbers'], {});
                         iptList.stdout.on('data', function (data) {
                             const iptLines = _.split(data.toString(), /(?:\r\n|\r|\n)/g);
@@ -413,7 +414,7 @@ class Server extends EventEmitter {
 
                         // Add NAT rule
                         // TODO : Check result code and report to log/console
-                        this.emit('console', `${Ansi.style.green}[Pterodactyl Daemon] Adding 1:1 NAT iptables rule: Internal=${IntIPAddress} / External=${ExtIPAddress}`);
+                        this.log.info(`Adding single 1:1 NAT iptables rule: Internal=${IntIPAddress} / External=${ExtIPAddress}`);
                         const iptAddExec = Process.spawn('iptables', ['-t', 'nat', '-A', 'POSTROUTING', '-s', IntIPAddress, '!', '-o', NETWORK_NAME, '-j', 'SNAT', '--to-source', ExtIPAddress], {});
                         iptAddExec.on('error', execErr => {
                             this.logger.error(execErr);

--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -386,7 +386,7 @@ class Server extends EventEmitter {
                         // TODO : Check result code and report log/console
                         this.emit('console', `${Ansi.style.green}[Pterodactyl Daemon] Configuring 1:1 NAT Network.`);
                         this.log.info(`Removing all 1:1 NAT iptables rules: Internal=${IntIPAddress} / External=${ExtIPAddress} on Interface ${NETWORK_NAME}`);
-                        const iptList = Process.spawn('iptables', ['-t', 'nat', '-L', 'POSTROUTING', '--line-numbers'], {});
+                        const iptList = Process.spawn('iptables', ['-w', '-n', '-t', 'nat', '-L', 'POSTROUTING', '--line-numbers'], {});
                         iptList.stdout.on('data', function (data) {
                             const iptLines = _.split(data.toString(), /(?:\r\n|\r|\n)/g);
                             if (iptLines && iptLines.length) {
@@ -397,7 +397,7 @@ class Server extends EventEmitter {
                                     }
                                 }
                                 for (let iptRules = iptRule.length - 1; iptRules >= 0; iptRules -= 1) {
-                                    const iptDelExec = Process.spawn('iptables', ['-t', 'nat', '-D', 'POSTROUTING', iptRule[iptRules]], {});
+                                    const iptDelExec = Process.spawn('iptables', ['-w', '-t', 'nat', '-D', 'POSTROUTING', iptRule[iptRules]], {});
                                     iptDelExec.on('error', execErr => {
                                         this.logger.error(execErr);
                                         return next(new Error('There was an error while adding iptables rule.'));
@@ -415,7 +415,7 @@ class Server extends EventEmitter {
                         // Add NAT rule
                         // TODO : Check result code and report to log/console
                         this.log.info(`Adding single 1:1 NAT iptables rule: Internal=${IntIPAddress} / External=${ExtIPAddress}`);
-                        const iptAddExec = Process.spawn('iptables', ['-t', 'nat', '-A', 'POSTROUTING', '-s', IntIPAddress, '!', '-o', NETWORK_NAME, '-j', 'SNAT', '--to-source', ExtIPAddress], {});
+                        const iptAddExec = Process.spawn('iptables', ['-w', '-t', 'nat', '-A', 'POSTROUTING', '-s', IntIPAddress, '!', '-o', NETWORK_NAME, '-j', 'SNAT', '--to-source', ExtIPAddress], {});
                         iptAddExec.on('error', execErr => {
                             this.logger.error(execErr);
                             return next(new Error('There was an error while adding iptables rule.'));

--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -371,7 +371,7 @@ class Server extends EventEmitter {
                 this.docker.start(callback);
             },
             callback => {
-                if (Config.get('docker.network.name') !== 'host' && (Config.get('docker.policy.network.enable_ip_masquerade') === 'false' || Config.get('docker.policy.network.enable_ip_masquerade') ==$
+                if (Config.get('docker.network.name') !== 'host' && (Config.get('docker.policy.network.enable_ip_masquerade') === 'false' || Config.get('docker.policy.network.enable_ip_masquerade') === false)) {
                     const NETWORK_NAME = Config.get('docker.network.name');
                     this.docker.container.inspect().then(results => {
                         const props = {

--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -382,17 +382,17 @@ class Server extends EventEmitter {
                         const ExtIPAddress = strEnv.substring(strEnv.indexOf('=', strEnv.indexOf('SERVER_IP')) + 1, strEnv.indexOf(',', strEnv.indexOf('=', strEnv.indexOf('SERVER_IP'))));
                         const IntIPAddress = props.IntIPAddress.toString();
 
-                        // Removes NAT rules
+                        // Removes all container related NAT rules
                         // TODO : Check result code and report log/console
                         this.emit('console', `${Ansi.style.green}[Pterodactyl Daemon] Removing 1:1 NAT iptables rule: Internal=${IntIPAddress} / External=${ExtIPAddress} on Interface ${NETWORK_NAME}`);
                         const iptList = Process.spawn('iptables', ['-t', 'nat', '-L', 'POSTROUTING', '--line-numbers'], {});
                         iptList.stdout.on('data', function (data) {
-                            const iptLines = data.toString().split(/(?:\r\n|\r|\n)/g);
+                            const iptLines = _.split(data.toString(), /(?:\r\n|\r|\n)/g);
                             if (iptLines && iptLines.length) {
                                 const iptRule = [];
                                 for (let iptLine = 0; iptLine < iptLines.length; iptLine += 1) {
-                                    if (iptLines[iptLine].includes('SNAT') && iptLines[iptLine].includes(IntIPAddress)) {
-                                        iptRule.push(iptLines[iptLine].split(' ', 1)[0]);
+                                    if (_.includes(iptLines[iptLine], 'SNAT') && _.includes(iptLines[iptLine], IntIPAddress)) {
+                                        iptRule.push(_.split(iptLines[iptLine], ' ', 1)[0]);
                                     }
                                 }
                                 for (let iptRules = iptRule.length - 1; iptRules >= 0; iptRules -= 1) {

--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -384,7 +384,7 @@ class Server extends EventEmitter {
 
                         // Removes all container related NAT rules
                         // TODO : Check result code and report log/console
-                        this.emit('console', `${Ansi.style.green}[Pterodactyl Daemon] Configuring 1:1 1:1 Network.`);
+                        this.emit('console', `${Ansi.style.green}[Pterodactyl Daemon] Configuring 1:1 NAT Network.`);
                         this.log.info(`Removing all 1:1 NAT iptables rules: Internal=${IntIPAddress} / External=${ExtIPAddress} on Interface ${NETWORK_NAME}`);
                         const iptList = Process.spawn('iptables', ['-t', 'nat', '-L', 'POSTROUTING', '--line-numbers'], {});
                         iptList.stdout.on('data', function (data) {

--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -385,8 +385,8 @@ class Server extends EventEmitter {
                         // Removes NAT rules
                         // TODO : Check result code and report log/console
                         this.emit('console', `${Ansi.style.green}[Pterodactyl Daemon] Removing 1:1 NAT iptables rule: Internal=${IntIPAddress} / External=${ExtIPAddress} on Interface ${NETWORK_NAME}`);
-                        const iptList = Process.spawn('iptables', ['-t','nat','-L','POSTROUTING','--line-numbers'], {});
-                        iptList.stdout.on('data', function(data) {
+                        const iptList = Process.spawn('iptables', ['-t', 'nat', '-L', 'POSTROUTING', '--line-numbers'], {});
+                        iptList.stdout.on('data', function (data) {
                             const iptLines = data.toString().split(/(?:\r\n|\r|\n)/g);
                             if (iptLines && iptLines.length) {
                                 const iptRule = [];

--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -382,7 +382,7 @@ class Server extends EventEmitter {
                             IntIPAddress: results.NetworkSettings.Networks[NETWORK_NAME].IPAddress,
                         };
                         const strEnv = props.Env.toString();
-                        const ExtIPAddress = strEnv.substring(strEnv.indexOf('=', strEnv.indexOf('SERVER_IP')) + 1, strEnv.indexOf(',', strEnv.indexOf('=', strEnv.indexOf('SERVER_IP'))));
+                        const ExtIPAddress = strEnv.substring(strEnv.indexOf('=', strEnv.indexOf('SERVER_IP=')) + 1, strEnv.indexOf(',', strEnv.indexOf('=', strEnv.indexOf('SERVER_IP='))));
                         const IntIPAddress = props.IntIPAddress.toString();
 
                         // Removes all container related NAT rules

--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -371,7 +371,10 @@ class Server extends EventEmitter {
                 this.docker.start(callback);
             },
             callback => {
-                if (Config.get('docker.network.name') !== 'host' && (Config.get('docker.policy.network.enable_ip_masquerade') === 'false' || Config.get('docker.policy.network.enable_ip_masquerade') === false)) {
+                // This section provides 1:1 NAT instead of the default Masquerading
+                // Useful if the node server has more public IP addresses, and the host network is not an option
+                // To enable the feature, enable_ip_masquerade in core.json must be set to "false"
+                if (Config.get('docker.network.name') !== 'host' && Config.get('docker.policy.network.enable_ip_masquerade') === 'false') {
                     const NETWORK_NAME = Config.get('docker.network.name');
                     this.docker.container.inspect().then(results => {
                         const props = {


### PR DESCRIPTION
Just a quick and dirty 1:1 NAT implementation on docker containers.
I'm sure someone with better skills can write/correct what I tried to implement, unfortunately I'm not a software developer.
NAT 1:1 permits to run every kind of gameserver behind a NAT interface, without the need to use a "host" network interface to resolve problems generated by a masquerading interface (Source based games for example). The "host" network interface unfortunately can not run games that do not support multihome IP. NAT 1:1 can do that and the security between containers is mantained.
There's no need to manage iptables rules, these rules can just be corrected on server start, no need to remove them on server stop/kill.

Thx for considering my 2 cents.