### PR TITLE
Improve readability in new symlink resolution

### DIFF
--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -585,7 +585,6 @@ class Server extends EventEmitter {
         // Dangerous path, do not rely on this as the final output location until running it through
         // the fs.realpath function.
         let returnPath = null;
-        let nonExistentPathRoot = null;
         const resolvedPath = Path.join(dataPath, Path.normalize(Querystring.unescape(location)));
 
         try {
@@ -621,7 +620,7 @@ class Server extends EventEmitter {
                 }
 
                 try {
-                    nonExistentPathRoot = Fs.realpathSync(pathParts.join('/'));
+                    returnPath = Fs.realpathSync(pathParts.join('/'));
                     return false;
                 } catch (loopError) {
                     if (loopError.code !== 'ENOENT') {
@@ -634,15 +633,6 @@ class Server extends EventEmitter {
                     pathParts.pop();
                 }
             });
-        }
-
-        // If we had to traverse the filesystem to resolve a path root we should check if the final
-        // resolution is within the server data directory. If so, return at this point, otherwise continue
-        // on and check aganist the normal return path.
-        if (!_.isNull(nonExistentPathRoot)) {
-            if (_.startsWith(nonExistentPathRoot, dataPath)) {
-                return nonExistentPathRoot;
-            }
         }
 
         if (_.startsWith(returnPath, dataPath)) {

--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -615,26 +615,24 @@ class Server extends EventEmitter {
             // and check the final path resoltuion for that directory. If there is an unexpected error or
             // we get to a point where the path is now shorter than the data path we will exit and return
             // the base data path.
-            _.some(pathParts, () => {
+            _.forEach(pathParts, () => {
                 if (pathParts.length < minLength) {
-                    return true;
+                    return false;
                 }
 
                 try {
                     nonExistentPathRoot = Fs.realpathSync(pathParts.join('/'));
-                    return true;
+                    return false;
                 } catch (loopError) {
                     if (loopError.code !== 'ENOENT') {
                         this.log.error(loopError);
-                        return true;
+                        return false;
                     }
 
                     // Pop the last item off the checked path so we can check one level up on
                     // the next loop iteration.
                     pathParts.pop();
                 }
-
-                return false;
             });
         }
 
@@ -643,7 +641,7 @@ class Server extends EventEmitter {
         // on and check aganist the normal return path.
         if (!_.isNull(nonExistentPathRoot)) {
             if (_.startsWith(nonExistentPathRoot, dataPath)) {
-                return resolvedPath;
+                return nonExistentPathRoot;
             }
         }
 


### PR DESCRIPTION
a) Returning resolvedPath at the end neglects everything we have done before and actually recreates the bug we have tried to resolve. We need to return nonExistentPathRoot (I left the original name, but it is misleading in my opinion), which is our new safe path

b) using _.some in this case makes no sense; this is the situation for forEach. I also made needed adjustments (return false equals break, while in _.some returning true breaks the loop). ESLint is also satisfied now, so Travis should not be failing anymore.