### PR TITLE
Reordered callback error check

### DIFF
--- a/src/controllers/option.js
+++ b/src/controllers/option.js
@@ -165,12 +165,12 @@ class Option {
                         container.remove();
                     }
 
-                    if (data.StatusCode !== 0) {
-                        return callback(new Error(`Install script failed with code ${data.StatusCode}`));
-                    }
-
                     if (err) {
                         return callback(err);
+                    }
+
+                    if (data.StatusCode !== 0) {
+                        return callback(new Error(`Install script failed with code ${data.StatusCode}`));
                     }
 
                     this.server.log.info('Completed installation process for server.');


### PR DESCRIPTION
Fixed a small mistake that can cause an undefined state if the Docker API returns with an error.

The current behaviour is an unwanted exception 
```
20:49:01.177Z FATAL wings: Cannot read property 'StatusCode' of null (path=/v1/servers, method=POST, server=82f1c836-a408-4d9a-b2cb-a04c3e654432)
    TypeError: Cannot read property 'StatusCode' of null
        at DockerController.run (/srv/daemon/src/controllers/option.js:168:30)
        at Object.callback (/srv/daemon/node_modules/dockerode/lib/docker.js:1412:25)
        at /srv/daemon/node_modules/dockerode/lib/container.js:404:12
        at /srv/daemon/node_modules/docker-modem/lib/modem.js:262:7
        at getCause (/srv/daemon/node_modules/docker-modem/lib/modem.js:284:7)
        at Modem.buildPayload (/srv/daemon/node_modules/docker-modem/lib/modem.js:253:5)
        at IncomingMessage.<anonymous> (/srv/daemon/node_modules/docker-modem/lib/modem.js:229:14)
        at emitNone (events.js:111:20)
        at IncomingMessage.emit (events.js:208:7)
        at endReadableNT (_stream_readable.js:1064:12)

```
This causes the whole process to abort which then prevents a "Install failed" notification at the front end. Also the pre-created install container is not getting deleted.