### PR TITLE
Increase timeout

### DIFF
--- a/src/controllers/routes.js
+++ b/src/controllers/routes.js
@@ -156,7 +156,7 @@ class RouteController {
                         'Content-Type': 'application/json',
                     },
                     followAllRedirects: true,
-                    timeout: 5000,
+                    timeout: 10000,
                 }, (requestErr, response, body) => {
                     if (requestErr || response.statusCode !== 200) {
                         Log.warn(requestErr, 'An error occured while attempting to alert the panel of server install status.', { code: (typeof response !== 'undefined') ? response.statusCode : null, responseBody: body });
@@ -282,7 +282,7 @@ class RouteController {
                         'Content-Type': 'application/json',
                     },
                     followAllRedirects: true,
-                    timeout: 5000,
+                    timeout: 10000,
                 }, (requestErr, response, body) => {
                     if (requestErr || response.statusCode !== 200) {
                         Log.warn(requestErr, 'An error occured while attempting to alert the panel of server install status.', { code: (typeof response !== 'undefined') ? response.statusCode : null, responseBody: body });


### PR DESCRIPTION
Increase timeout to 10 seconds from 5. Some users have an issue where it times out before it can notify the panel of the install status, upping this limit seems to resolve it.