### PR TITLE
Fix server mem usage being sometimes inaccurate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 This file is a running track of new features and fixes to each version of the daemon released starting with `v0.2.0`.
 
+## v0.6.13 (Elasticized Elanodactylus)
+### Fixed
+* Fixes server memory usage calculations to match the logic of the `docker stats` command.
+
 ## v0.6.12 (Elasticized Elanodactylus)
 ### Fixed
 * Fixes a bug with the packs system that would not properly handle an error response from the panel resulting in the server

--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -719,7 +719,7 @@ class Server extends EventEmitter {
         }, () => {
             self.processData.process = { // eslint-disable-line
                 memory: {
-                    total: self.docker.procData.memory_stats.usage,
+                    total: self.docker.procData.memory_stats.usage - self.docker.procData.memory_stats.stats.cache,
                     cmax: self.docker.procData.memory_stats.max_usage,
                     amax: self.json.build.memory * 1000000,
                 },


### PR DESCRIPTION
Matches the resource usage to same logic used in docker stats (https://github.com/docker/cli/blob/aa097cf1aa19099da70930460250797c8920b709/cli/command/container/stats_helpers.go#L230)
Should fix: https://github.com/pterodactyl/panel/issues/1696