### PR TITLE
getos changes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -189,9 +189,11 @@ Async.auto({
                     UserCommand = `addgroup -S ${Username} && adduser -S -D -H -G ${Username} -s /bin/false ${Username}`;
                     break;
                 case 'Ubuntu Linux':
+                case 'Ubuntu':
                 case 'Debian':
                 case 'Fedora':
                 case 'Centos':
+                case 'CentOS':
                 case 'RHEL':
                 case 'Red Hat Linux':
                     UserCommand = `useradd --system --no-create-home --shell /bin/false ${Username}`;


### PR DESCRIPTION
Added `Ubuntu`


Added `CentOS`
^ Not sure if js is case sensitive or not? but should probably have both.

`getos` made these changes Apr 1st in v3.2.0
https://github.com/retrohacker/getos/commit/58e84254077e1b537d576708d70e20d35c80bb94

Closes https://github.com/pterodactyl/panel/issues/2023