### PR TITLE
Added User-Agent

### DIFF
--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -29,6 +29,7 @@ const Inquirer = require('inquirer');
 const Request = require('request');
 const Fs = require('fs-extra');
 const Path = require('path');
+const Package = rfr('package.json');
 
 const CONFIG_PATH = Path.resolve('config/core.json');
 const CONFIG_EXISTS = Fs.existsSync(CONFIG_PATH);
@@ -155,7 +156,7 @@ Inquirer.prompt([
     Request.get({
         url: `${params.panelurl.value}/daemon/configure/${params.token.value}`,
         headers: {
-            'User-Agent': 'wings/0.6.13 (Linux x86_64)'
+            'User-Agent': `wings/${Package.version} (Linux x86_64)`,
         },
     }, (error, response, body) => {
         if (!error) {

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -152,7 +152,12 @@ Inquirer.prompt([
 
     // Fetch configuration from the panel
     console.log('Fetching configuration from panel.');
-    Request.get(`${params.panelurl.value}/daemon/configure/${params.token.value}`, (error, response, body) => {
+    Request.get({
+        url: `${params.panelurl.value}/daemon/configure/${params.token.value}`,
+        headers: {
+            'User-Agent': 'wings/0.6.13 (Linux x86_64)'
+        },
+    }, (error, response, body) => {
         if (!error) {
             // response should always be JSON
             const jsonBody = JSON.parse(body);

--- a/src/controllers/option.js
+++ b/src/controllers/option.js
@@ -34,6 +34,7 @@ const isStream = require('isstream');
 const createOutputStream = require('create-output-stream');
 
 const ConfigHelper = rfr('src/helpers/config.js');
+const Package = rfr('package.json');
 const ImageHelper = rfr('src/helpers/image.js');
 
 const Config = new ConfigHelper();
@@ -58,6 +59,7 @@ class Option {
             headers: {
                 'Accept': 'application/vnd.pterodactyl.v1+json',
                 'Authorization': `Bearer ${Config.get('keys.0')}`,
+                'User-Agent': `wings/${Package.version} (Linux x86_64)`,
             },
         }, (err, resp) => {
             if (err) return next(err);

--- a/src/controllers/pack.js
+++ b/src/controllers/pack.js
@@ -33,6 +33,7 @@ const Crypto = require('crypto');
 const Process = require('child_process');
 
 const Log = rfr('src/helpers/logger.js');
+const Package = rfr('package.json');
 const ConfigHelper = rfr('src/helpers/config.js');
 const Config = new ConfigHelper();
 
@@ -111,6 +112,7 @@ class Pack {
                     url: endpoint,
                     headers: {
                         'X-Access-Node': Config.get('keys.0'),
+                        'User-Agent': `wings/${Package.version} (Linux x86_64)`,
                     },
                 }, (err, resp) => {
                     if (err) {
@@ -178,7 +180,11 @@ class Pack {
                 Log.debug('Downloading pack...');
                 const endpoint = `${Config.get('remote.base')}/daemon/packs/pull/${this.pack}`;
 
-                Request({ method: 'GET', url: endpoint, headers: { 'X-Access-Node': Config.get('keys.0') } })
+                Request({ method: 'GET', url: endpoint,
+                headers: { 
+                    'X-Access-Node': Config.get('keys.0'),
+                    'User-Agent': `wings/${Package.version} (Linux x86_64)`,
+                 } })
                     .on('error', error => {
                         callback(error);
                     })

--- a/src/controllers/routes.js
+++ b/src/controllers/routes.js
@@ -154,6 +154,7 @@ class RouteController {
                         'X-Access-Node': Config.get('keys.0'),
                         'Accept': 'application/json',
                         'Content-Type': 'application/json',
+                        'User-Agent': `wings/${Package.version} (Linux x86_64)`,
                     },
                     followAllRedirects: true,
                     timeout: 10000,
@@ -280,6 +281,7 @@ class RouteController {
                         'X-Access-Node': Config.get('keys.0'),
                         'Accept': 'application/json',
                         'Content-Type': 'application/json',
+                        'User-Agent': `wings/${Package.version} (Linux x86_64)`,
                     },
                     followAllRedirects: true,
                     timeout: 10000,
@@ -540,6 +542,7 @@ class RouteController {
             headers: {
                 'Accept': 'application/vnd.pterodactyl.v1+json',
                 'Authorization': `Bearer ${Config.get('keys.0')}`,
+                'User-Agent': `wings/${Package.version} (Linux x86_64)`,
             },
             timeout: 5000,
         }, (err, response, body) => {

--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -45,6 +45,7 @@ const FileSystem = require('./fs');
 const OptionController = require('./option');
 const ServiceCore = require('./../services/index');
 const Errors = require('./../errors/index');
+const Package = rfr('package.json');
 
 const Config = new ConfigHelper();
 
@@ -173,7 +174,7 @@ class Server extends EventEmitter {
             headers: {
                 'Accept': 'application/vnd.pterodactyl.v1+json',
                 'Authorization': `Bearer ${Config.get('keys.0')}`,
-                'User-Agent': 'wings/0.6.13 (Linux x86_64)'
+                'User-Agent': `wings/${Package.version} (Linux x86_64)`,
             },
         }, (err, response, body) => {
             if (err) {

--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -173,6 +173,7 @@ class Server extends EventEmitter {
             headers: {
                 'Accept': 'application/vnd.pterodactyl.v1+json',
                 'Authorization': `Bearer ${Config.get('keys.0')}`,
+                'User-Agent': 'wings/0.6.13 (Linux x86_64)'
             },
         }, (err, response, body) => {
             if (err) {

--- a/src/controllers/service.js
+++ b/src/controllers/service.js
@@ -30,6 +30,7 @@ const Crypto = require('crypto');
 const _ = require('lodash');
 
 const Log = rfr('src/helpers/logger.js');
+const Package = rfr('package.json');
 const ConfigHelper = rfr('src/helpers/config.js');
 
 const Config = new ConfigHelper();
@@ -87,6 +88,7 @@ class Service {
             headers: {
                 'Accept': 'application/vnd.pterodactyl.v1+json',
                 'Authorization': `Bearer ${Config.get('keys.0')}`,
+                'User-Agent': `wings/${Package.version} (Linux x86_64)`,
             },
         }, (err, response, body) => {
             if (err) return next(err);
@@ -114,6 +116,7 @@ class Service {
             headers: {
                 'Accept': 'application/vnd.pterodactyl.v1+json',
                 'Authorization': `Bearer ${Config.get('keys.0')}`,
+                'User-Agent': `wings/${Package.version} (Linux x86_64)`,
             },
         }, (err, response, body) => {
             if (err) return next(err);

--- a/src/http/restify.js
+++ b/src/http/restify.js
@@ -27,6 +27,7 @@ const Fs = require('fs-extra');
 const Restify = require('restify');
 const Bunyan = require('bunyan');
 const Path = require('path');
+const Package = rfr('package.json');
 
 const ConfigHelper = rfr('src/helpers/config.js');
 const Config = new ConfigHelper();

--- a/src/http/routes.js
+++ b/src/http/routes.js
@@ -26,6 +26,7 @@ const rfr = require('rfr');
 const Restify = require('restify');
 const Util = require('util');
 
+const Package = rfr('package.json');
 const Log = rfr('src/helpers/logger.js');
 const LoadConfig = rfr('src/helpers/config.js');
 const AuthorizationMiddleware = rfr('src/middleware/authorizable.js');

--- a/src/http/sftp.js
+++ b/src/http/sftp.js
@@ -40,6 +40,7 @@ const OPEN_MODE = Ssh2.SFTP_OPEN_MODE;
 const STATUS_CODE = Ssh2.SFTP_STATUS_CODE;
 
 const Log = rfr('src/helpers/logger.js');
+const Package = rfr('package.json');
 const ConfigHelper = rfr('src/helpers/config.js');
 const Servers = rfr('src/helpers/initialize.js').Servers;
 const SFTPQueue = rfr('src/helpers/sftpqueue.js');
@@ -67,6 +68,7 @@ class InternalSftpServer {
                         },
                         headers: {
                             'Authorization': `Bearer ${Config.get('keys.0')}`,
+                            'User-Agent': `wings/${Package.version} (Linux x86_64)`,
                         },
                     }, (err, response, body) => {
                         if (err) {


### PR DESCRIPTION
Added User-Agent to allow for easier traffic filtration on Cloudflare.

Case:
Someone has 50+ nodes and has strict firewalling set up on Cloudflare.
Deploying a new node means the account user will have to add another rule to allow that server to pass through.

Adding a User-Agent will drastically simplify that process since the account user only has to allow
User-Agent to pass through rather than whitelisting an empty UA which is commonly used by other attackers too.
