### PR TITLE
Fix SFTP WRITE commands writing to disk out of order

### DIFF
--- a/src/http/sftp.js
+++ b/src/http/sftp.js
@@ -455,7 +455,7 @@ class InternalSftpServer {
                                 }
 
                                 // The writer is closed in the sftp.on('CLOSE') listener.
-                                Fs.write(requestData.writer, data, 0, data.length, null, error => {
+                                Fs.write(requestData.writer, data, 0, data.length, offset, error => {
                                     if (error) {
                                         clientContext.server.log.warn({
                                             path: requestData.path,


### PR DESCRIPTION
In short: I noticed that quite alot of files had problems when uploading them via the SFTP server. After comparing a include file, I noticed that a part of the file got written before it was supposed to: https://www.diffchecker.com/pVVpleLk. After hours of tests I realized that `offset` was being ignored when writing to disk.

Details: [this gif](https://gfycat.com/KlutzyChillyBobolink) shows what was happening. The same file being uploaded (just a random config duplicated a few times to trigger this problem more consistently) showed up with different MD5 sums. Each time I uploaded the file, the resulting file would be different. 

This happened even with max connections set to 1. `WRITE` commands were received in order (I logged a few uploads and every single one of them had the exact same length, hash/content in the same order).

Reducing upload speed helped a bit but didn't solve the problem.

After updating the `stfp.js` file to use `offset`, I manage to finally upload the files as expected: [gif](https://gfycat.com/enlightenedbelatedbobolink). Their sums change during the upload but they always remained the same. I could not replicate the problem even with big (2k files 100MB) configs. So I guess it's 100% fixed after 10h of painful debugging.

I'm not sure if this only happens when using `mergerfs`, could not test without it. 